### PR TITLE
fixed jd float error

### DIFF
--- a/resume_first.py
+++ b/resume_first.py
@@ -102,7 +102,10 @@ if st.session_state["resume_uploaded"] and st.session_state["selected_job"] is N
             with st.expander(f"{job['title']} at {job['company']}"):
                 st.write(f"**Location:** {job.get('location', 'Location not specified')}")
                 st.write(f"**Job Type:** {job.get('job_type', 'Not provided')}")
-                st.write(f"**Description:** {job.get('description', 'No description available')[:500]}...")
+                description = job.get('description', 'No description available')
+                description = str(description)  # 确保是字符串
+                st.write(f"**Description:** {description[:500]}...")
+
 
                 if st.button("Select This Job", key=f"select_job_{idx}"):
                     st.session_state["selected_job"] = job


### PR DESCRIPTION
This pull request includes a small change to the `search_jobs` function in the `resume_first.py` file. The change ensures that the job description is always treated as a string before truncating it for display.

* [`resume_first.py`](diffhunk://#diff-d5fa6ac9aac463bd91880b23bf9c0ccb132f50fd7a05021a8e1d4a8568d82a22L105-R108): Modified the `search_jobs` function to convert the job description to a string to prevent potential errors when slicing.